### PR TITLE
投稿削除機能修正

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,5 +1,5 @@
 class Tweet < ApplicationRecord
-  has_many :comments
+  has_many :comments, dependent: :destroy
   belongs_to :user
   has_one_attached :image
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :tweets
-  has_many :comments
+  has_many :tweets, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_one_attached :avatar
 
   validates :name, presence: true


### PR DESCRIPTION
## WHAT
投稿削除機能を修正した。

## WHY
ツイートに紐付いたコメント、ユーザーに紐付いたツイートとコメントが削除できていなかったため。