### PR TITLE
バリデーション変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_one_attached :avatar
 
-  validates :name, presence: true, length: { maximum: 6 }, uniqueness: true
+  validates :name, presence: true, length: { maximum: 10 }, uniqueness: true
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, length: { minimum: 6 }
   validates :password_confirmation, presence: true, length: { minimum: 6 }

--- a/spec/model/user_spec.rb
+++ b/spec/model/user_spec.rb
@@ -31,14 +31,14 @@ describe User do
       expect(user.errors[:password_confirmation]).to include("doesn't match Password")
     end
 
-    it "is invalid name 6文字以上" do
-      user = build(:user, name: "hidehide")
+    it "is invalid name 10文字以上" do
+      user = build(:user, name: "hidehidehide")
       user.valid?
-      expect(user.errors[:name]).to include("is too long (maximum is 6 characters)")
+      expect(user.errors[:name]).to include("is too long (maximum is 10 characters)")
     end
 
-    it "is valid name 6文字以下" do
-      user = build(:user, name: "jinjin")
+    it "is valid name 10文字以下" do
+      user = build(:user, name: "jinjinhide")
       expect(user).to be_valid
     end
 


### PR DESCRIPTION
## WHAT
Userテーブルのnameカラムに関するバリデーションを変更。

## WHY
6文字以上の名前は登録できないようになっていたので、10文字まで登録できるように変更した。