### PR TITLE
Commentモデル(単体)テスト修正

### DIFF
--- a/spec/model/comment_spec.rb
+++ b/spec/model/comment_spec.rb
@@ -1,29 +1,36 @@
 require 'rails_helper'
-describe Comment do
+
+RSpec.describe Comment, type: :model do
   describe '#create' do
+    context 'can save' do
     
-    it "is valid with a text" do
-      comment = build(:comment)
-      expect(comment).to be_valid
+      it "is valid with a text" do
+        comment = build(:comment)
+        expect(comment).to be_valid
+      end
+    
     end
 
-    it "is invalid without a text" do
-      comment = build(:comment, text: "")
-      comment.valid?
-      expect(comment.errors[:text]).to include("can't be blank")
-    end
+    context 'can not save' do
 
-    it "is invalid without user_id" do
-      comment = build(:comment, user_id: nil)
-      comment.valid?
-      expect(comment.errors[:user]).to include("can't be blank")
-    end
+      it "is invalid without a text" do
+        comment = build(:comment, text: "")
+        comment.valid?
+        expect(comment.errors[:text]).to include("can't be blank")
+      end
 
-    it "is invalid without tweet_id" do
-      comment = build(:comment, tweet_id: nil)
-      comment.valid?
-      expect(comment.errors[:tweet]).to include("can't be blank")
-    end
-  
+      it "is invalid without user_id" do
+        comment = build(:comment, user_id: nil)
+        comment.valid?
+        expect(comment.errors[:user]).to include("can't be blank")
+      end
+
+      it "is invalid without tweet_id" do
+        comment = build(:comment, tweet_id: nil)
+        comment.valid?
+        expect(comment.errors[:tweet]).to include("can't be blank")
+      end
+
+    end  
   end
 end


### PR DESCRIPTION
## WHAT
慣習に従う記述に変更。
保存できる場合と保存できない時場合を分けた。

## WHY
慣習に従う記述になっていなかったため。
また、コードを見やすくするため。
